### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/myesguer/9a2ea48a-5d39-4fc9-aa96-b67721b62617/8b8bc9c9-56c0-4aec-ba8d-2d3164847347/_apis/work/boardbadge/80ba69a4-d9c0-459d-943b-0ec5efda365e)](https://dev.azure.com/myesguer/9a2ea48a-5d39-4fc9-aa96-b67721b62617/_boards/board/t/8b8bc9c9-56c0-4aec-ba8d-2d3164847347/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/myesguer/9a2ea48a-5d39-4fc9-aa96-b67721b62617/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.